### PR TITLE
Alternative implementation based on an OwnedEnv.

### DIFF
--- a/native/mutable_storage/src/lib.rs
+++ b/native/mutable_storage/src/lib.rs
@@ -42,6 +42,7 @@ struct Buffer {
 
 fn load(env: Env, _: Term) -> bool {
     rustler::resource!(Buffer, env);
+    rustler::resource!(TermArc, env);
     true
 }
 
@@ -237,28 +238,63 @@ fn buffer_resize(resource: ResourceArc<Buffer>, new_size: usize) -> Atom {
 }
 
 #[rustler::nif]
-fn term_new(term: Term) -> ResourceArc<Buffer> {
-    let data = term.to_binary().to_vec();
-    let buffer = Buffer {
-        data: RwLock::new(data),
-    };
-
-    ResourceArc::new(buffer)
+fn term_new(term: Term) -> ResourceArc<TermArc> {
+    ResourceArc::new(TermArc::new(term.clone()))
 }
 
 #[rustler::nif]
-fn term_get(env: Env, resource: ResourceArc<Buffer>) -> Term {
-    let term_binary = resource.data.read().unwrap();
-    let (term, _size) = env.binary_to_term(term_binary.as_slice()).unwrap();
-    term
+fn term_get<'a>(env: Env<'a>, resource: ResourceArc<TermArc>) -> Term<'a> {
+    resource.get(env)
 }
 
 #[rustler::nif]
-fn term_set(resource: ResourceArc<Buffer>, term: Term) -> Atom {
-    let mut data = resource.data.write().unwrap();
-    data.clear();
-    data.write(term.to_binary().as_slice()).unwrap();
-    data.shrink_to_fit();
+fn term_set(resource: ResourceArc<TermArc>, term: Term) -> Atom {
+    resource.set(term)
+}
 
-    atoms::ok()
+use rustler::env::OwnedEnv;
+use rustler::env::SavedTerm;
+
+#[derive(Clone)]
+pub struct TermArc
+{
+    inner: std::sync::Arc<std::sync::Mutex<TermArcAux>>,
+}
+
+pub struct TermArcAux
+{
+    owned_env: OwnedEnv,
+    saved_term: SavedTerm
+}
+
+impl TermArc {
+    pub fn new(term: Term) -> Self {
+        Self{inner: std::sync::Arc::new(std::sync::Mutex::new(TermArcAux::new(term)))}
+    }
+
+    pub fn get<'a>(&self, env: Env<'a>) -> Term<'a> {
+        let inner = self.inner.lock().unwrap();
+
+        // Copy over term from owned environment to the target environment
+        inner.owned_env.run(|inner_env| {
+            let term = inner.saved_term.load(inner_env);
+            term.in_env(env)
+        })
+    }
+
+    pub fn set(&self, term: Term) -> Atom {
+        let mut term_ptr = self.inner.lock().unwrap();
+        term_ptr.owned_env.clear();
+        term_ptr.saved_term = term_ptr.owned_env.save(term);
+
+        atoms::ok()
+    }
+}
+
+impl TermArcAux {
+    pub fn new(term: Term) -> Self {
+        let owned_env = OwnedEnv::new();
+        let saved_term = owned_env.save(term);
+        Self{owned_env: owned_env, saved_term: saved_term}
+    }
 }


### PR DESCRIPTION
I have no clue as to the performance of this implementation, but it at least is able to store Erlang references correctly and it does not leak memory.

c.f. https://github.com/chrrasmussen/Idris2-Erlang/issues/4